### PR TITLE
Fix Unicorn spriteTexture becoming public in SDV 1.5

### DIFF
--- a/DeepWoodsMod/Unicorn.cs
+++ b/DeepWoodsMod/Unicorn.cs
@@ -252,7 +252,7 @@ namespace DeepWoodsMod
             if (isPetted)
                 return;
 
-            typeof(AnimatedSprite).GetField("spriteTexture", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(this.Sprite, DeepWoodsTextures.Textures.Unicorn);
+            this.Sprite.spriteTexture = DeepWoodsTextures.Textures.Unicorn;
             base.draw(b);
         }
 


### PR DESCRIPTION
"Sprite.spriteTexture" became a public field in SDV 1.5, and Unicorn's reflection code was using the "NonPublic" flag to access it, so there were some draw errors when they spawned.

This change should fix the errors reported in [kaiteliz's NexusMods comment](https://forums.nexusmods.com/index.php?showtopic=6856647/#entry88462198) (i.e. [this log](https://smapi.io/log/a3073ddc7fae449daada8dcfcddf7157)). It's also been tested by someone who had the issue in SDV's Discord modding channel earlier.